### PR TITLE
Task/fix gensism version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Version 1.3.3 - Patch release - 2021-09-08
+- Fixed gensism version to avoid api conflict with Flair package

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,5 +1,6 @@
 torch==1.6.0
 flair==0.6.1
+gensim==3.8.0
 flask>=1.0,<1.1
 tqdm==4.50.0
 spacy==2.3.2

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "named-entity-recognition",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "meta": {
         "label": "Named Entity Recognition",
         "category": "Natural Language Processing",


### PR DESCRIPTION
Fix gensism version to 3.8.0 because newer version has api conflict with flair package.

![image](https://user-images.githubusercontent.com/10564525/132517452-a6a49f03-4cd0-4a91-9391-78626fc55879.png)
