### PR TITLE
Add support for python 3.8, 3.9

### DIFF
--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,8 +1,12 @@
 {
     "acceptedPythonInterpreters": [
         "PYTHON36",
-        "PYTHON37"
+        "PYTHON37",
+        "PYTHON38",
+        "PYTHON39",
+        "PYTHON310"
     ],
+    "corePackagesSet": "AUTO",
     "forceConda": false,
     "installCorePackages": true,
     "installJupyterSupport": false

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -3,8 +3,7 @@
         "PYTHON36",
         "PYTHON37",
         "PYTHON38",
-        "PYTHON39",
-        "PYTHON310"
+        "PYTHON39"
     ],
     "corePackagesSet": "AUTO",
     "forceConda": false,

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,11 +1,18 @@
+# 'flair' doesn't support python 3.11 as of v0.12.2 (Mar 30, 2023)
 flair==0.11.3
+
+# 'gensim' didn't support python 3.10 and 3.11 prior to v4.3.0 (Dec 21, 2022)
+gensim==3.8.0; python_version < '3.10'
+gensim==4.3.0; python_version >= '3.10'
+
 flask>=2.0,<2.1
-gensim==3.8.0
-numpy==1.19.5
-spacy[ja]==3.3.0
+numpy==1.19.5; python_version < '3.8'
+numpy>1.19,<1.24; python_version >= '3.8'
 tokenizers==0.10.3; python_version == '3.6'
 sudachipy==0.6.0; python_version == '3.6'
 tqdm==4.50.0
+
+spacy[ja]==3.3.0
 https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.3.0/en_core_web_sm-3.3.0.tar.gz
 # https://github.com/explosion/spacy-models/releases/download/es_core_news_sm-3.3.0/es_core_news_sm-3.3.0.tar.gz
 # https://github.com/explosion/spacy-models/releases/download/zh_core_web_sm-3.3.0/zh_core_web_sm-3.3.0.tar.gz

--- a/custom-recipes/named-entity-recognition-extract/recipe.py
+++ b/custom-recipes/named-entity-recognition-extract/recipe.py
@@ -59,11 +59,12 @@ def compute_entities_df(df):
     out_df = df.merge(out_df, left_index=True, right_index=True)
     return out_df
 
-if ner_model == "spacy":
-    chunksize = 200 * multiprocessing.cpu_count()
-else:
-    chunksize = 100
+if __name__ == '__main__':
+    if ner_model == "spacy":
+        chunksize = 200 * multiprocessing.cpu_count()
+    else:
+        chunksize = 100
 
-process_dataset_chunks(
-    input_dataset=input_dataset, output_dataset=output_dataset, func=compute_entities_df, chunksize=chunksize
-)
+    process_dataset_chunks(
+        input_dataset=input_dataset, output_dataset=output_dataset, func=compute_entities_df, chunksize=chunksize
+    )


### PR DESCRIPTION
I didn't add support for python 3.11 because 'flair' doesn't support it yet.

And since there may still exist issues with 'flair'+python 3.10 (e.g. ['sentencepiece' installation may fail](https://github.com/google/sentencepiece/issues/732)), I prefer not to support it yet.