### PR TITLE
Pin sudachipy for python 3.7 and 3.8

### DIFF
--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -16,6 +16,7 @@ numpy==1.19.5; python_version < '3.8'
 numpy>1.19,<1.24; python_version >= '3.8'
 tokenizers==0.10.3; python_version == '3.6'
 sudachipy==0.6.0; python_version == '3.6'
+sudachipy<0.6.10; python_version >= '3.7' and python_version < '3.9'
 tqdm==4.50.0
 
 typing_extensions<4.6.0 # https://github.com/explosion/spaCy/issues/12659 => remove when spacy is bumped


### PR DESCRIPTION
Sudachipy released on the 10th of january 2025 version 0.6.10, with no wheels for python3.8 and before : 

https://pypi.org/project/SudachiPy/0.6.10/#files