### PR TITLE
Fix and improve unit testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Git
+.git
+.gitignore
+.github
+
+# IDE
+.idea
+.vscode
+*.iml
+
+# Python
+__pycache__
+*.py[cod]
+*.egg-info
+.eggs
+*.egg
+.tox
+env/
+venv/
+.venv/
+.pytest_cache
+
+# Build artifacts
+dist/
+build/
+
+# Documentation
+*.md
+LICENSE
+
+# CI/CD
+Jenkinsfile
+Dockerfile
+
+# Other
+.DS_Store
+*.log

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # 3.6 and 3.7 not supported on free runners Ubuntu >= 24.04
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,42 @@
+name: Unit Tests
+
+on:
+  push:
+    branches: [master]  # Only run push on default branch after merge
+  pull_request:         # Run on all PRs
+
+# Cancel in-progress runs when a new commit is pushed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.6 and 3.7 not supported on free runners Ubuntu >= 24.04
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          tests/python/unit/requirements.txt
+          code-env/python/spec/requirements.txt
+
+    - name: Install dependencies
+      run: |
+        pip install -r tests/python/unit/requirements.txt
+        pip install -r code-env/python/spec/requirements.txt
+
+    - name: Run tests
+      env:
+        PYTHONPATH: python-lib
+      run: pytest tests/python/unit -v

--- a/python-lib/ner/flair.py
+++ b/python-lib/ner/flair.py
@@ -38,6 +38,8 @@ def get_model(model_id: str):
     elif model_provider is not None:
         # dl model with provider at hugging face proper location, return pytorch bin path
         model_path = "%s/pytorch_model.bin" % model_provider.get_or_download_model(FLAIR_MODEL_PROVIDER_MAPPING[model_id])
+    else:
+        raise KeyError("Unknown model_id '{}'. Available: {}".format(model_id, list(FLAIR_LANGUAGE_MODELS_LEGACY_MAPPING.keys())))
     return SequenceTagger.load(model_path)
 
 def extract_entities(text_column, format, model_id):

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,34 @@
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /plugin
+
+# Copy requirements files first (for better layer caching)
+COPY code-env/python/spec/requirements.txt /plugin/requirements-plugin.txt
+COPY tests/python/unit/requirements.txt /plugin/requirements-test.txt
+
+# Install dependencies
+RUN pip install --upgrade pip && \
+    pip install --no-cache-dir -r requirements-test.txt && \
+    pip install --no-cache-dir -r requirements-plugin.txt
+
+# Copy source code and resources
+COPY python-lib/ /plugin/python-lib/
+COPY resource/ /plugin/resource/
+COPY tests/python/unit/ /plugin/tests/python/unit/
+
+# Set environment variables
+ENV PYTHONPATH=/plugin/python-lib
+
+# Run tests with system info
+CMD echo "=== System Info ===" && \
+    echo "OS: $(cat /etc/os-release | grep PRETTY_NAME | cut -d'=' -f2)" && \
+    echo "Architecture: $(uname -m)" && \
+    echo "Python: $(python --version)" && \
+    echo "Pip: $(pip --version)" && \
+    echo "==================" && \
+    pytest tests/python/unit -v

--- a/tests/python/unit/python-lib/ner/test_flair.py
+++ b/tests/python/unit/python-lib/ner/test_flair.py
@@ -1,7 +1,6 @@
 import json
 
 import pandas as pd
-from flair.models import SequenceTagger
 
 from ner.constants import (
     COLUMN_PER_ENTITY_FORMAT,
@@ -13,10 +12,9 @@ from ner.flair import extract_entities
 TEST_SENTENCE = "Mark Zuckerberg is one of the founders of Facebook, a company from the United States"
 
 def test_extract_entities():
-    tagger = SequenceTagger.load("flair/ner-english-fast@3d3d35790f78a00ef319939b9004209d1d05f788")
     df = pd.DataFrame({'text': [TEST_SENTENCE]})
     pd.testing.assert_frame_equal(
-        extract_entities(df['text'], JSON_LABELING_FORMAT, tagger),
+        extract_entities(df['text'], JSON_LABELING_FORMAT, "en"),
         pd.DataFrame({
             'sentence': [TEST_SENTENCE],
             'entities': json.dumps([
@@ -27,7 +25,7 @@ def test_extract_entities():
         })
     )
     pd.testing.assert_frame_equal(
-        extract_entities(df['text'], COLUMN_PER_ENTITY_FORMAT, tagger),
+        extract_entities(df['text'], COLUMN_PER_ENTITY_FORMAT, "en"),
         pd.DataFrame({
             'sentence': [TEST_SENTENCE],
             'LOC': json.dumps(['United States']),
@@ -36,7 +34,7 @@ def test_extract_entities():
         })
     )
     pd.testing.assert_frame_equal(
-        extract_entities(df['text'], JSON_KEY_PER_ENTITY_FORMAT, tagger),
+        extract_entities(df['text'], JSON_KEY_PER_ENTITY_FORMAT, "en"),
         pd.DataFrame({
             'sentence': [TEST_SENTENCE],
             'entities': json.dumps({

--- a/tests/python/unit/python-lib/ner/test_flair.py
+++ b/tests/python/unit/python-lib/ner/test_flair.py
@@ -1,13 +1,16 @@
+# -*- coding: utf-8 -*-
 import json
 
 import pandas as pd
+import pytest
+from flair.models import SequenceTagger
 
 from ner.constants import (
     COLUMN_PER_ENTITY_FORMAT,
     JSON_KEY_PER_ENTITY_FORMAT,
     JSON_LABELING_FORMAT
 )
-from ner.flair import extract_entities
+from ner.flair import extract_entities, get_model
 
 TEST_SENTENCE = "Mark Zuckerberg is one of the founders of Facebook, a company from the United States"
 
@@ -42,6 +45,58 @@ def test_extract_entities():
                 'ORG': ['Facebook'],
                 'LOC': ['United States'],
             })
-            
         })
     )
+
+def test_extract_entities_empty_text():
+    df = pd.DataFrame({'text': ['']})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    assert result['sentence'].iloc[0] == ''
+    assert json.loads(result['entities'].iloc[0]) == []
+
+def test_extract_entities_no_entities():
+    df = pd.DataFrame({'text': ['Hello world, this is a simple test.']})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    assert result['sentence'].iloc[0] == 'Hello world, this is a simple test.'
+    assert json.loads(result['entities'].iloc[0]) == []
+
+def test_extract_entities_unicode():
+    unicode_text = 'Müller works at Nestlé in Zürich.'
+    df = pd.DataFrame({'text': [unicode_text]})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    # Verify unicode text is preserved correctly
+    assert result['sentence'].iloc[0] == unicode_text
+    # Verify valid JSON output (no encoding errors)
+    entities = json.loads(result['entities'].iloc[0])
+    assert isinstance(entities, list)
+
+def test_extract_entities_multiple_same_type():
+    df = pd.DataFrame({'text': ['John and Mary went to Paris and London.']})
+    result = extract_entities(df['text'], COLUMN_PER_ENTITY_FORMAT, "en")
+    assert len(result) == 1
+    # Should have multiple entities, check that PER or LOC columns exist with arrays
+    if 'PER' in result.columns:
+        per_entities = json.loads(result['PER'].iloc[0])
+        assert isinstance(per_entities, list)
+    if 'LOC' in result.columns:
+        loc_entities = json.loads(result['LOC'].iloc[0])
+        assert isinstance(loc_entities, list)
+
+def test_extract_entities_multiple_rows():
+    df = pd.DataFrame({'text': [
+        'Apple is based in California.',
+        'Microsoft was founded by Bill Gates.'
+    ]})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 2
+
+def test_get_model_legacy_mapping():
+    model = get_model("en")
+    assert isinstance(model, SequenceTagger)
+
+def test_get_model_invalid_id():
+    with pytest.raises(KeyError):
+        get_model("invalid_language_code")

--- a/tests/python/unit/python-lib/ner/test_spacy.py
+++ b/tests/python/unit/python-lib/ner/test_spacy.py
@@ -1,13 +1,16 @@
+# -*- coding: utf-8 -*-
 import json
+
 import pandas as pd
+import pytest
+import spacy
 
 from ner.constants import (
     COLUMN_PER_ENTITY_FORMAT,
     JSON_KEY_PER_ENTITY_FORMAT,
     JSON_LABELING_FORMAT
 )
-from ner.spacy import extract_entities
-
+from ner.spacy import extract_entities, get_model, SPACY_LANGUAGE_MODELS_LEGACY_MAPPING
 
 TEST_SENTENCE = "Mark Zuckerberg is one of the founders of Facebook, a company from the United States"
 
@@ -44,3 +47,67 @@ def test_extract_entities():
             })
         })
     )
+
+def test_extract_entities_empty_text():
+    df = pd.DataFrame({'text': ['']})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    assert result['sentence'].iloc[0] == ''
+    assert json.loads(result['entities'].iloc[0]) == []
+
+def test_extract_entities_no_entities():
+    df = pd.DataFrame({'text': ['Hello world, this is a simple test.']})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    assert result['sentence'].iloc[0] == 'Hello world, this is a simple test.'
+    assert json.loads(result['entities'].iloc[0]) == []
+
+def test_extract_entities_unicode():
+    unicode_text = 'Müller works at Nestlé in Zürich.'
+    df = pd.DataFrame({'text': [unicode_text]})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 1
+    # Verify unicode text is preserved correctly
+    assert result['sentence'].iloc[0] == unicode_text
+    # Verify valid JSON output (no encoding errors)
+    entities = json.loads(result['entities'].iloc[0])
+    assert isinstance(entities, list)
+
+def test_extract_entities_multiple_same_type():
+    df = pd.DataFrame({'text': ['John and Mary went to Paris and London.']})
+    result = extract_entities(df['text'], COLUMN_PER_ENTITY_FORMAT, "en")
+    assert len(result) == 1
+    # Should have multiple entities, check that PERSON or GPE columns exist with arrays
+    if 'PERSON' in result.columns:
+        person_entities = json.loads(result['PERSON'].iloc[0])
+        assert isinstance(person_entities, list)
+    if 'GPE' in result.columns:
+        gpe_entities = json.loads(result['GPE'].iloc[0])
+        assert isinstance(gpe_entities, list)
+
+def test_extract_entities_multiple_rows():
+    df = pd.DataFrame({'text': [
+        'Apple is based in California.',
+        'Microsoft was founded by Bill Gates.'
+    ]})
+    result = extract_entities(df['text'], JSON_LABELING_FORMAT, "en")
+    assert len(result) == 2
+
+def test_get_model_english():
+    model = get_model("en")
+    assert model is not None
+    assert hasattr(model, 'pipe')
+
+def test_get_model_french():
+    model = get_model("fr")
+    assert model is not None
+    assert hasattr(model, 'pipe')
+
+def test_get_model_invalid_id():
+    with pytest.raises(KeyError):
+        get_model("invalid_language_code")
+
+def test_language_models_mapping_completeness():
+    expected_languages = ["en", "es", "zh", "pl", "fr", "de", "ja", "nb"]
+    for lang in expected_languages:
+        assert lang in SPACY_LANGUAGE_MODELS_LEGACY_MAPPING

--- a/tests/python/unit/requirements.txt
+++ b/tests/python/unit/requirements.txt
@@ -1,2 +1,13 @@
 pytest~=6.2
 allure-pytest~=2.8
+
+# Pandas - aligned with DSS 14.2 defaults
+pandas>=1.1,<1.2; python_version == '3.6'
+pandas>=1.3,<1.4; python_version == '3.7'
+pandas>=1.5,<1.6; python_version == '3.8'
+pandas>=2.2,<2.3; python_version >= '3.9'
+
+# NumPy - aligned with DSS 14.2 defaults
+numpy<1.24; python_version < '3.8'
+numpy<1.25; python_version == '3.8'
+numpy>=2,<2.1; python_version >= '3.9'


### PR DESCRIPTION
Various code changes related to testability
- Fix unit tests (broken after signature change [PR#17](https://github.com/dataiku/dss-plugin-nlp-named-entity-recognition/pull/17/changes#diff-79ebccc6bb7ec9d8db5065be99b555dfffe19c57b26eecab90aee7b87f015a69L14))
- Add test coverage
- Raise "clean" error when using unknown model_id with flair
- Pin unit tests requirements to match DSS default pandas and numpy versions
- Add utility to execute unit tests in debian docker containers
  - `make docker-test-py39`
- Add GHA workflow to execute unit tests on different python versions